### PR TITLE
added semantic ui and Status.templateOptions

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -27,6 +27,10 @@ var helpers = {
 
   reconnectLabel: function () {
     return i18n_status_func('meteor_status_try_now', { context: Meteor.status().status })
+  },
+
+  classes: function () {
+    return Status.templateOptions().classes
   }
 }
 

--- a/package.js
+++ b/package.js
@@ -20,6 +20,7 @@ Package.onUse(function (api) {
 
   api.addFiles('lib/status.html',           'client')
   api.addFiles('templates/bootstrap3.html', 'client')
+  api.addFiles('templates/semantic-ui.html', 'client')
 
   // Always after templates
   api.addFiles('i18n/en.i18n.json', ['client', 'server'])

--- a/status.js
+++ b/status.js
@@ -1,11 +1,21 @@
 var template = new ReactiveVar('bootstrap3')
+var templateOptions = new ReactiveVar({ 
+  classes: 'alert-warning'
+})
 
 Status = {
   template: function () {
     return template.get()
   },
 
-  setTemplate: function (name) {
+  templateOptions: function () {
+    return templateOptions.get()
+  },
+
+  setTemplate: function (name, options) {
     template.set(name)
+    if (options) {
+      templateOptions.set(options)
+    }
   }
 }

--- a/templates/bootstrap3.html
+++ b/templates/bootstrap3.html
@@ -1,6 +1,6 @@
 <template name="status_bootstrap3">
   {{#unless connected}}
-    <div class="alert text-center" role="alert">
+    <div class="alert {{classes}} text-center" role="alert">
       <strong>
         <span class="glyphicon glyphicon-warning-sign"></span>
         {{message}}

--- a/templates/bootstrap3.html
+++ b/templates/bootstrap3.html
@@ -1,6 +1,6 @@
 <template name="status_bootstrap3">
   {{#unless connected}}
-    <div class="alert alert-warning text-center" role="alert">
+    <div class="alert text-center" role="alert">
       <strong>
         <span class="glyphicon glyphicon-warning-sign"></span>
         {{message}}

--- a/templates/semantic-ui.html
+++ b/templates/semantic-ui.html
@@ -1,0 +1,15 @@
+<template name="status_semantic_ui">
+  {{#unless connected}}
+    <div class="ui {{classes}} message">
+      <div class="content">
+        <div class="header">
+          {{message}} &nbsp;
+          {{extraMessage}}
+          {{#if showReconnect}}
+            <a href="#" class="alert-link">{{reconnectLabel}}</a>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+  {{/unless}}
+</template>


### PR DESCRIPTION
I added semantic ui template as per your request. Additionally I took the liberty of extending your pattern with options. The reason for this is some semantic ui users will not want the 'attached' class I added to my message. Now devs can also change the color/alert-type of both templates (e.g. 'alert-warning').

Let me know what you think.