### PR TITLE
Set interval to update retryTime only when needed

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -1,5 +1,10 @@
 var retryTime = new ReactiveVar(0);
 var retryHandle;
+var clearInterval = function () {
+  if (retryHandle) {
+    Meteor.clearInterval(retryHandle);
+  }
+};
 
 var helpers = {
   connected: function () {
@@ -28,6 +33,7 @@ var helpers = {
   }
 };
 
+Template.status.onDestroyed(clearInterval);
 Template.status.onCreated(function () {
   this.autorun(function () {
     // The autorun will re-run whenever Meteor.status() changes, as 
@@ -43,9 +49,8 @@ Template.status.onCreated(function () {
 
         retryTime.set(_retryTime);
       }, 500);
-    } else if (retryHandle) {
-      Meteor.clearInterval(retryHandle);
-      retryHandle = null;
+    } else {
+      clearInterval();
     }
   });
 });

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,6 +1,6 @@
 var retryTime = new ReactiveVar(0);
 var retryHandle;
-var clearInterval = function () {
+var clearRetryInterval = function () {
   if (retryHandle) {
     Meteor.clearInterval(retryHandle);
   }
@@ -33,7 +33,7 @@ var helpers = {
   }
 };
 
-Template.status.onDestroyed(clearInterval);
+Template.status.onDestroyed(clearRetryInterval);
 Template.status.onCreated(function () {
   this.autorun(function () {
     // The autorun will re-run whenever Meteor.status() changes, as 
@@ -50,7 +50,7 @@ Template.status.onCreated(function () {
         retryTime.set(_retryTime);
       }, 500);
     } else {
-      clearInterval();
+      clearRetryInterval();
     }
   });
 });

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,52 +1,68 @@
-var retryTime = new ReactiveVar(0)
-
-Meteor.setInterval(function () {
-  var timeDiff   = Meteor.status().retryTime - (new Date).getTime()
-  var _retryTime = Math.round(timeDiff / 1000)
-
-  retryTime.set(_retryTime)
-}, 500)
+var retryTime = new ReactiveVar(0);
+var retryHandle;
 
 var helpers = {
   connected: function () {
-    return Meteor.status().connected
+    return Meteor.status().connected;
   },
 
   message: function () {
-    return i18n_status_func('meteor_status', { context: Meteor.status().status })
+    return i18n_status_func('meteor_status', { context: Meteor.status().status });
   },
 
   extraMessage: function () {
     if (Meteor.status().status === 'waiting')
-      return i18n_status_func('meteor_status_reconnect_in', { count: retryTime.get() })
+      return i18n_status_func('meteor_status_reconnect_in', { count: retryTime.get() });
   },
 
   showReconnect: function () {
-    return _.contains(['waiting', 'offline'], Meteor.status().status)
+    return _.contains(['waiting', 'offline'], Meteor.status().status);
   },
 
   reconnectLabel: function () {
-    return i18n_status_func('meteor_status_try_now', { context: Meteor.status().status })
+    return i18n_status_func('meteor_status_try_now', { context: Meteor.status().status });
   },
 
   option: function (option) {
-    return Status.option(option)
+    return Status.option(option);
   }
-}
+};
+
+Template.status.onCreated(function () {
+  this.autorun(function () {
+    // The autorun will re-run whenever Meteor.status() changes, as 
+    // Meteor.status() is a reactive source. This allows us to
+    // set the interval to update the retry time only when we need
+    // to, i.e when the status changes to the 'waiting' status. When
+    // the status switches back from 'waiting' to something else, 
+    // clear the interval since we don't need it anymore.
+    if (Meteor.status().status === 'waiting') {
+      retryHandle = Meteor.setInterval(function () {
+        var timeDiff   = Meteor.status().retryTime - (new Date).getTime();
+        var _retryTime = Math.round(timeDiff / 1000);
+
+        retryTime.set(_retryTime);
+      }, 500);
+    } else if (retryHandle) {
+      Meteor.clearInterval(retryHandle);
+      retryHandle = null;
+    }
+  });
+});
 
 Template.status.helpers({
   template: function () {
-    return 'status_' + Status.template()
+    return 'status_' + Status.template();
   },
 
   helpers: function () {
-    return helpers
+    return helpers;
   }
-})
+});
 
 Template.status.events({
   'click a.alert-link': function (e) {
-    e.preventDefault()
-    Meteor.reconnect()
+    e.preventDefault();
+    Meteor.reconnect();
   }
-})
+});

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name:    'francocatena:status',
   summary: 'Display the connection status between the browser and the Meteor server',
-  version: '1.2.4',
+  version: '1.2.5',
   git:     'https://github.com/francocatena/meteor-status',
 })
 


### PR DESCRIPTION
This is a pretty neat package, thanks for your work! 

Just thought I'd make a minor change: when `Meteor.status().status` is not `waiting` and when the status template is not in view, we don't need to keep running the interval. Tested it briefly and things look like they're in working order. Let me know what you think :-)